### PR TITLE
Generate the S3 bucket for build artifacts

### DIFF
--- a/template/cicd.yaml
+++ b/template/cicd.yaml
@@ -14,6 +14,12 @@ Parameters:
         Default: master
 
 Resources:
+  RecordServiceS3Bucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    Properties:
+      BucketName: !Join ['machine-learning-ecs-', [!Ref 'AWS::AccountId']]
+      
   CodePipelineCodeBuildServiceRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
The build fails unless this bucket is created for CodePipeline Artifact Store.
[build.yaml.zip](https://github.com/awslabs/ecs-mxnet-example/files/906873/build.yaml.zip)

